### PR TITLE
fix: respect PHP_MEMORY_LIMIT for composer

### DIFF
--- a/7.2/s2i/bin/assemble
+++ b/7.2/s2i/bin/assemble
@@ -41,7 +41,7 @@ if [ -f composer.json ]; then
   fi
 
   # Install App dependencies using Composer
-  ./composer.phar install --no-interaction --no-ansi --optimize-autoloader $COMPOSER_ARGS
+  php -d memory_limit=$PHP_MEMORY_LIMIT ./composer.phar install --no-interaction --no-ansi --optimize-autoloader $COMPOSER_ARGS
 
   if [ ! -f composer.lock ]; then
     echo -e "\nConsider adding a 'composer.lock' file into your source repository.\n"


### PR DESCRIPTION
After setting PHP_MEMORY_LIMIT to `-1` composer still exited with an OOM error.
Setting the parameter directly through php fixed the issue